### PR TITLE
Von Mises Calving Law

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ p/
 #files that should generally be ignored
 code/libamrfile/libamrfile_python.png
 code/libamrfile/python/AMRFile/amrfile/__pycache__/
+
+bisicles_compile*

--- a/code/src/AmrIce.H
+++ b/code/src/AmrIce.H
@@ -1330,6 +1330,9 @@ protected:
   // if true, include (cell-averaged) viscous tensor components in plotfiles
   bool m_write_viscousTensor;
 
+  // if true, include (cell-averaged) von Mises stress in plotfiles
+  bool m_write_vonmisesStress;
+
   // if true, include base velocity in plotfiles
   bool m_write_baseVel;
 

--- a/code/src/CalvingF.ChF
+++ b/code/src/CalvingF.ChF
@@ -24,3 +24,46 @@ c--------------------------------------------------------------
       CHF_ENDDO
       return
       end
+
+
+c--------------------------------------------------------------
+c compute von Mises Stress
+c--------------------------------------------------------------
+
+
+      subroutine vonmises(CHF_FRA1[vm],
+     &     CHF_CONST_FRA[T],
+     &     CHF_CONST_FRA1[h],
+     &     CHF_INT[xxComp],
+     &     CHF_INT[xyComp],
+     &     CHF_INT[yxComp],
+     &     CHF_Int[yyComp],
+     &     CHF_CONST_REAL[eps],
+     &     CHF_BOX[box])
+
+       integer CHF_AUTOIX[i]
+       REAL_T txx, txy, tyx, tyy, tvm
+
+       CHF_AUTOMULTIDO[box; i]
+#if (CH_SPACEDIM == 1)
+
+       ! Divide by h to convert from viscous tensor to stress
+       vm(CHF_AUTOIX[i]) = T(CHF_AUTOIX[i],0)/(h(CHF_AUTOIX[i])+eps)
+
+#elif (CH_SPACEDIM == 2)
+
+       txx = T(CHF_AUTOIX[i], xxComp)
+       tyy = T(CHF_AUTOIX[i], yyComp)
+       txy = T(CHF_AUTOIX[i], xyComp)
+       tyx = T(CHF_AUTOIX[i], yxComp)
+
+       tvm = (txx**2 + tyy**2 - txx*tyy + 3*(half*(txy+tyx))**2)**half
+
+       ! Divide by h to convert from viscous tensor to stress
+       vm(CHF_AUTOIX[i]) = tvm/(h(CHF_AUTOIX[i])+eps);
+
+#endif
+
+       CHF_ENDDO
+       return
+       end

--- a/code/src/CalvingModel.H
+++ b/code/src/CalvingModel.H
@@ -592,6 +592,56 @@ public:
 
 };
 
+/// A Calving model that provides a rate with a part proportional to speed and effective (Von Mises) stress and a part independent of speed and stress
+/**
+   The rate is either a face-centred vector (opposed to ice velocity)
+   or a cell-centered scalar
+
+   The rate is r = a u/|u| + sig_vm/sig_max u
+
+   sig_vm is the Von Mises Stress
+   The constants a and sig_max may be specified by SurfaceData.
+
+ */
+
+class VonMisesCalvingModel : public CalvingModel
+{
+
+  Real m_startTime, m_endTime;
+  DomainEdgeCalvingModel* m_domainEdgeCalvingModel;
+  SurfaceFlux* m_independent; // a 
+  SurfaceFlux* m_scale; // sig_max**-1
+  bool m_vector; // face-centred vector or cell-centred scalar?
+
+public:
+
+  virtual void applyCriterion(LevelData<FArrayBox>& a_thickness, 
+ 			      LevelData<FArrayBox>& a_calvedIce,
+			      LevelData<FArrayBox>& a_addedIce,
+			      LevelData<FArrayBox>& a_removedIce,
+			      LevelData<FArrayBox>& a_iceFrac, 
+			      const AmrIce& a_amrIce,
+			      int a_level,
+			      Stage a_stage);
+  
+  VonMisesCalvingModel (ParmParse& a_pp);
+
+  virtual ~VonMisesCalvingModel();
+  
+  virtual CalvingModel* new_CalvingModel();
+
+  ///frontal ablation vector.
+  virtual bool getCalvingVel (LevelData<FluxBox>& a_faceCalvingVel,
+			      const LevelData<FluxBox>& a_faceIceVel,
+			      const LevelData<FArrayBox>& a_centreIceVel,
+			      const DisjointBoxLayout& a_grids,
+			      const AmrIce& a_amrIce,int a_level);
+  
+  virtual void getCalvingRate(LevelData<FArrayBox>& a_calvingRate, 
+			      const AmrIce& a_amrIce,int a_level);
+
+};
+
 
 #include "NamespaceFooter.H"
 


### PR DESCRIPTION
Implemented a von Mises calving law (c.f. [Morlighem et al 2016](https://doi.org/10.1002/2016GL067695)) based on the RateProportionalToSpeed model (with a proportional term and a constant) that computes the von Mises stress from the cell-averaged, vertically integrated viscousTensor. User provides the scale 1./sigma_max as a surface flux.