### PR TITLE
Updating package requirements for Ubunutu site specific notes

### DIFF
--- a/code/mk/Make.defs
+++ b/code/mk/Make.defs
@@ -21,7 +21,9 @@ CHOMBO_HOME := $(BISICLES_HOME)/Chombo/lib
 endif
 
 #GIA code depends on fftw
-USE_FFTW := TRUE
+#Turning off for now (TMM 14/02/24)
+#USE_FFTW := TRUE
+USE_FFTW := FALSE
 #Guess FFTWDIR if it is not specified. 
 ifeq ($(FFTWDIR),)
 FFTWDIR=/usr

--- a/code/src/BuelerGIA.H
+++ b/code/src/BuelerGIA.H
@@ -7,7 +7,9 @@
  *    Please refer to Copyright.txt, in Chombo's root directory.
  */
 #endif
-#ifdef FFTW_3
+/* Not using for now (TMM 14/02/24)
+#ifdef FFTW_3*/
+#if USE_FFTW
 #ifndef _BUELERGIA_H_
 #define _BUELERGIA_H_
 #define BUELERGIA

--- a/code/src/BuelerGIA.cpp
+++ b/code/src/BuelerGIA.cpp
@@ -13,7 +13,9 @@
  * Date: Jan 19, 2019
  *
  */
-#if FFTW_3
+/* Not using for now (TMM 14/02/24)
+#if FFTW_3*/
+#if USE_FFTW
 #include "BuelerGIA.H"
 #include <fftw3.h>
 #include "BisiclesF_F.H"

--- a/docs/sites.html
+++ b/docs/sites.html
@@ -33,7 +33,7 @@
   hdf5, and netcdf to be installed in a way that works well for BISICLES. On Ubuntu 22.04 run
 </p>
 <pre>
-  sudo apt install subversion build-essential g++ gfortran csh mpi-default-bin mpi-default-dev libhdf5-mpi-dev libhdf5-dev hdf5-tools libnetcdff-dev libnetcdf-dev python3 python3-dev libpython3-dev
+  sudo apt install subversion build-essential g++ gfortran csh mpi-default-bin mpi-default-dev libhdf5-mpi-dev libhdf5-dev hdf5-tools libnetcdff-dev libnetcdf-dev python3 python3-dev libpython3-dev fftw3-dev
 </pre>
 <p>
 If you want to use python for analysis you will need the usual libraries (numpy, matplotlib etc) 


### PR DESCRIPTION
Added fftw3-dev to the list of packages needed to be installed on Ubunutu 22.04 for the code to compile